### PR TITLE
Rollback both databases

### DIFF
--- a/lib/tasks/stagehand_tasks.rake
+++ b/lib/tasks/stagehand_tasks.rake
@@ -25,7 +25,19 @@ namespace :stagehand do
       end
     end
   end
+
+  desc "Rollback both databases used by stagehand"
+  task :rollback => :environment do
+    connections = [Stagehand.configuration.staging_connection_name, Stagehand.configuration.production_connection_name]
+    connections.compact.uniq.each do |connection_name|
+      puts "Rolling back #{connection_name}"
+      Stagehand::Database.with_connection(connection_name) do
+        ActiveRecord::Migrator.rollback("db/migrate")
+      end
+    end
+  end
 end
 
-# Enhance the regular db:migrate task to run the stagehand migration task so both stagehand databases are migrated
+# Enhance the regular db:migrate/db:rollback tasks to run the stagehand migration/rollback tasks so both stagehand databases are migrated
 Rake::Task['db:migrate'].enhance(['stagehand:migrate'])
+Rake::Task['db:rollback'].enhance(['stagehand:rollback'])

--- a/lib/tasks/stagehand_tasks.rake
+++ b/lib/tasks/stagehand_tasks.rake
@@ -17,7 +17,6 @@ namespace :stagehand do
 
   desc "Migrate both databases used by stagehand"
   task :migrate => :environment do
-    puts "Migrating"
     run_on_both_databases do
       ActiveRecord::Migrator.migrate('db/migrate')
     end
@@ -25,7 +24,6 @@ namespace :stagehand do
 
   desc "Rollback both databases used by stagehand"
   task :rollback => :environment do
-    puts "Rolling back"
     run_on_both_databases do
       ActiveRecord::Migrator.rollback("db/migrate")
     end
@@ -35,7 +33,7 @@ end
 def run_on_both_databases(&block)
   connections = [Stagehand.configuration.staging_connection_name, Stagehand.configuration.production_connection_name]
   connections.compact.uniq.each do |connection_name|
-    puts "The #{connection_name}"
+    puts "#{connection_name}"
     Stagehand::Database.with_connection(connection_name, &block)
   end
 end

--- a/lib/tasks/stagehand_tasks.rake
+++ b/lib/tasks/stagehand_tasks.rake
@@ -11,33 +11,35 @@ namespace :stagehand do
   end
 
   desc "Syncs all records to production, including those that require confirmation"
-  task :sync_all, :environment do
+  task :sync_all => :environment do
     Stagehand::Staging::Synchronizer.sync_all
   end
 
   desc "Migrate both databases used by stagehand"
   task :migrate => :environment do
-    connections = [Stagehand.configuration.staging_connection_name, Stagehand.configuration.production_connection_name]
-    connections.compact.uniq.each do |connection_name|
-      puts "Migrating #{connection_name}"
-      Stagehand::Database.with_connection(connection_name) do
-        ActiveRecord::Migrator.migrate('db/migrate')
-      end
+    puts "Migrating"
+    run_on_both_databases do
+      ActiveRecord::Migrator.migrate('db/migrate')
     end
   end
 
   desc "Rollback both databases used by stagehand"
   task :rollback => :environment do
-    connections = [Stagehand.configuration.staging_connection_name, Stagehand.configuration.production_connection_name]
-    connections.compact.uniq.each do |connection_name|
-      puts "Rolling back #{connection_name}"
-      Stagehand::Database.with_connection(connection_name) do
-        ActiveRecord::Migrator.rollback("db/migrate")
-      end
+    puts "Rolling back"
+    run_on_both_databases do
+      ActiveRecord::Migrator.rollback("db/migrate")
     end
   end
 end
 
+def run_on_both_databases(&block)
+  connections = [Stagehand.configuration.staging_connection_name, Stagehand.configuration.production_connection_name]
+  connections.compact.uniq.each do |connection_name|
+    puts "The #{connection_name}"
+    Stagehand::Database.with_connection(connection_name, &block)
+  end
+end
+
 # Enhance the regular db:migrate/db:rollback tasks to run the stagehand migration/rollback tasks so both stagehand databases are migrated
-Rake::Task['db:migrate'].enhance(['stagehand:migrate'])
-Rake::Task['db:rollback'].enhance(['stagehand:rollback'])
+Rake::Task['db:migrate'].clear.enhance(['stagehand:migrate'])
+Rake::Task['db:rollback'].clear.enhance(['stagehand:rollback'])


### PR DESCRIPTION
Since the Migrate/Rollback use the same code to run on both databases, I pulled out the dup code and just pass in the unique part as a block.

Since .enhance runs both methods, we were calling migrate/rollback twice which was causing rollback issues. Found that you can overwrite a task with .clear so that it clears the existing prerequisites and actions of a rake task, then call enhance to run the task we really want.

Looking into how we could pass command line options to our custom task 
ie. rake db:rollback STEP=4  
In this case, we could access the STEP=4. I was hoping the .enhance would let us pass the whole db:rollback over to enhance method, but I think it runs the first method and then runs the next. So I don't have access to these options. On the bright side, since we are now overwriting the db:rollback it won't be an issue of Mismatched databases. But it would still be ideal if we could have our task mimic the way the db:rollback (and the way the user would expect it to work).
