### PR TITLE
Allowing non-dual-migration and updating readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -315,9 +315,9 @@ Both staging and production databases need to be migrated to allow syncing to oc
 
 The default behaviour of `db:migrate` and `db:rollback` have been enhanced to migrate or rollback both the staging and production databases.
 
-This enhancement comes with a caveat, db:migrate/db:rollback can no longer take options (for example: `rake db:migrate VERSION=20080906120000`, or `rake db:rollback STEP=2`)
+This enhancement comes with a caveat, db:migrate/db:rollback can no longer take options (for example: `rake db:migrate VERSION=20080906120000`, or `rake db:rollback STEP=2` will run as `rake db:migrate` and `rake db:rollback`, respectively, and ignore the options defined).
 
-The migration enhancement behaviour can be disabled by setting ENV['STAGEHAND_ENHANCE_MIGRATION'] to false. (for example: `STAGEHAND_ENHANCE_MIGRATION=false rake db:migrate`)
+The migration enhancement behaviour can be disabled by setting ENV['STAGEHAND_ENHANCE_MIGRATION'] to false. (for example: `STAGEHAND_ENHANCE_MIGRATION=false rake db:migrate`, will run `rake db:migrate` on the current database but not the second one).
 
 ### create_table
 

--- a/Readme.md
+++ b/Readme.md
@@ -309,9 +309,15 @@ config.x.stagehand.ghost_mode = true
 
 ## Database Migrations
 
-Both staging and production databases need to be migrated to allow syncing to occur. The default behaviour of db:migrate
-has been enhanced to migrate both staging and production databases. If the two databases have different schema versions,
-a `Stagehand::SchemaMismatch` exception will be raised when trying to sync.
+Both staging and production databases need to be migrated to allow syncing to occur. If the two databases have different schema versions, a `Stagehand::SchemaMismatch` exception will be raised when trying to sync.
+
+### db:migrate/db:rollback
+
+The default behaviour of `db:migrate` and `db:rollback` have been enhanced to migrate or rollback both the staging and production databases.
+
+This enhancement comes with a caveat, db:migrate/db:rollback can no longer take options (for example: `rake db:migrate VERSION=20080906120000`, or `rake db:rollback STEP=2`)
+
+The migration enhancement behaviour can be disabled by setting ENV['STAGEHAND_ENHANCE_MIGRATION'] to false. (for example: `STAGEHAND_ENHANCE_MIGRATION=false rake db:migrate`)
 
 ### create_table
 
@@ -321,7 +327,7 @@ is extended to automatically call `add_stagehand!` on the new table.
 ### rename_table
 
 In order to ensure that change tracking triggers are not left recording the wrong table name after the table is renamed,
-the `rename_table` schema migration method is extended to automatically `remove_stagehand!``
+the `rename_table` schema migration method is extended to automatically `remove_stagehand!`
 
 
 ## Error Detection

--- a/lib/tasks/stagehand_tasks.rake
+++ b/lib/tasks/stagehand_tasks.rake
@@ -43,5 +43,7 @@ def run_on_both_databases(&block)
 end
 
 # Enhance the regular db:migrate/db:rollback tasks to run the stagehand migration/rollback tasks so both stagehand databases are migrated
-Rake::Task['db:migrate'].enhance(['stagehand:migrate'])
-Rake::Task['db:rollback'].enhance(['stagehand:rollback'])
+unless ENV['STAGEHAND_ENHANCE_MIGRATION'] == 'false'
+  Rake::Task['db:migrate'].enhance(['stagehand:migrate'])
+  Rake::Task['db:rollback'].enhance(['stagehand:rollback'])
+end


### PR DESCRIPTION
Adding ability for users to turn off the dual migration/rollback enhancements. Updating readme.
