### PR TITLE
Support HABTM associations without a model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    culturecode_stagehand (0.7.12)
+    culturecode_stagehand (0.7.13)
       mysql2
       rails (~> 4.2)
 
@@ -50,7 +50,7 @@ GEM
     concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    globalid (0.3.6)
+    globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
     json (1.8.3)
@@ -120,7 +120,7 @@ GEM
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
     slop (3.6.0)
-    sprockets (3.6.3)
+    sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.1.1)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -13,20 +13,25 @@
 
 ActiveRecord::Schema.define(version: 0) do
 
+  create_table "habtm_records", force: :cascade do |t|
+  end
+
   create_table "source_records", force: :cascade do |t|
-    t.string   "name",       limit: 255
+    t.string   "name",            limit: 255
+    t.integer  "counter",         limit: 4
+    t.string   "type",            limit: 255
+    t.integer  "user_id",         limit: 4
+    t.integer  "attachable_id",   limit: 4
+    t.string   "attachable_type", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "stagehand_commit_entries", force: :cascade do |t|
-    t.integer "record_id",  limit: 4
-    t.string  "table_name", limit: 255
-    t.string  "operation",  limit: 255, null: false
-    t.integer "commit_id",  limit: 4
-    t.string  "session",    limit: 255
+  create_table "target_assignments", force: :cascade do |t|
+    t.integer  "source_record_id", limit: 4
+    t.integer  "target_id",        limit: 4
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
   end
-
-  add_index "stagehand_commit_entries", ["session"], name: "index_stagehand_commit_entries_on_session", using: :btree
 
 end

--- a/spec/lib/staging/commit_entry_spec.rb
+++ b/spec/lib/staging/commit_entry_spec.rb
@@ -57,7 +57,12 @@ describe Stagehand::Staging::CommitEntry do
 
       it 'raises an exception if the record class could not be determined from the table_name' do
         entry = klass.create(:record_id => 1, :table_name => 'fake_table', :operation => :insert)
-        expect { subject.record_class }.to raise_exception(Stagehand::IndeterminateRecordClass)
+        expect { subject.record_class }.to raise_exception(Stagehand::MissingTable)
+      end
+
+      it 'creates a dummy class if the record class could not be determined from the table_name but the table exists' do
+        subject = klass.create(:record_id => 1, :table_name => 'habtm_records', :operation => :insert)
+        expect(subject.record_class.name).to eq('HabtmRecord')
       end
     end
   end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -27,6 +27,9 @@ RSpec.configure do |config|
             t.references :target
             t.timestamps :null => false
           end
+
+          create_table :habtm_records, :force => true do |t|
+          end
         end
       end
     end


### PR DESCRIPTION
If we can’t find a model, but the table exists, create a placeholder model so we can instantiate the record like any other.