### PR TITLE
Unsynced writes to production now raise an exception

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    culturecode_stagehand (0.9.1)
+    culturecode_stagehand (0.9.2)
       mysql2
       rails (~> 4.2)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    culturecode_stagehand (0.9.2)
+    culturecode_stagehand (0.10.0)
       mysql2
       rails (~> 4.2)
 
@@ -125,7 +125,7 @@ GEM
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.1.1)
+    sprockets-rails (3.2.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)

--- a/lib/stagehand/configuration.rb
+++ b/lib/stagehand/configuration.rb
@@ -20,6 +20,11 @@ module Stagehand
       !!Rails.configuration.x.stagehand.ghost_mode
     end
 
+    # Allow unsynchronized writes directly to the production database? A warning will be logged if set to true.
+    def allow_unsynced_production_writes?
+      !!Rails.configuration.x.stagehand.allow_unsynced_production_writes
+    end
+
     # Returns true if the production and staging connections are the same.
     # Use case: Front-end devs may not have a second database set up as they are only concerned with the front end
     def single_connection?

--- a/lib/stagehand/connection_adapter_extensions.rb
+++ b/lib/stagehand/connection_adapter_extensions.rb
@@ -48,7 +48,7 @@ module Stagehand
       private
 
       def update_readonly_state
-        readonly! if @config[:database] == Database.production_database_name
+        readonly! unless Configuration.single_connection? || @config[:database] != Database.production_database_name
       end
 
       def clear_readonly_state

--- a/lib/stagehand/connection_adapter_extensions.rb
+++ b/lib/stagehand/connection_adapter_extensions.rb
@@ -61,7 +61,7 @@ module Stagehand
         elsif Configuration.allow_unsynced_production_writes?
           Rails.logger.warn "Writing directly to production database"
         else
-          raise(ProductionWrite, "Attempted to write directly to production database")
+          raise(UnsyncedProductionWrite, "Attempted to write directly to production database")
         end
       end
     end
@@ -70,7 +70,7 @@ module Stagehand
 
   # EXCEPTIONS
 
-  class ProductionWrite < StandardError; end
+  class UnsyncedProductionWrite < StandardError; end
 end
 
 ActiveRecord::Base.connection.class.prepend(Stagehand::Connection::AdapterExtensions)

--- a/lib/stagehand/connection_adapter_extensions.rb
+++ b/lib/stagehand/connection_adapter_extensions.rb
@@ -1,0 +1,76 @@
+module Stagehand
+  module Connection
+    def self.with_production_writes(model, &block)
+      state = model.connection.readonly?
+      model.connection.readonly!(false)
+      return block.call
+    ensure
+      model.connection.readonly!(state)
+    end
+
+    module AdapterExtensions
+      def self.prepended(base)
+        base.set_callback :checkout, :after, :update_readonly_state
+        base.set_callback :checkin, :before, :clear_readonly_state
+      end
+
+      def exec_insert(*)
+        handle_readonly_writes!
+        super
+      end
+
+      def exec_update(*)
+        handle_readonly_writes!
+        super
+      end
+
+      def exec_delete(*)
+        handle_readonly_writes!
+        super
+      end
+
+      def allow_writes(&block)
+        state = readonly?
+        readonly!(true)
+        return block.call
+      ensure
+        readonly!(state)
+      end
+
+      def readonly!(state = true)
+        @readonly = state
+      end
+
+      def readonly?
+        !!@readonly
+      end
+
+      private
+
+      def update_readonly_state
+        readonly! if @config[:database] == Database.production_database_name
+      end
+
+      def clear_readonly_state
+        readonly!(false)
+      end
+
+      def handle_readonly_writes!
+        if !readonly?
+          return
+        elsif Configuration.allow_unsynced_production_writes?
+          puts "Writing directly to production database"
+        else
+          raise(ProductionWrite, "Attempted to write directly to production database")
+        end
+      end
+    end
+  end
+
+
+  # EXCEPTIONS
+
+  class ProductionWrite < StandardError; end
+end
+
+ActiveRecord::Base.connection.class.prepend(Stagehand::Connection::AdapterExtensions)

--- a/lib/stagehand/connection_adapter_extensions.rb
+++ b/lib/stagehand/connection_adapter_extensions.rb
@@ -59,7 +59,7 @@ module Stagehand
         if !readonly?
           return
         elsif Configuration.allow_unsynced_production_writes?
-          puts "Writing directly to production database"
+          Rails.logger.warn "Writing directly to production database"
         else
           raise(ProductionWrite, "Attempted to write directly to production database")
         end

--- a/lib/stagehand/database.rb
+++ b/lib/stagehand/database.rb
@@ -52,15 +52,19 @@ module Stagehand
     def with_connection(connection_name)
       different = current_connection_name != connection_name.to_sym
 
-      @@connection_name_stack.push(connection_name.to_sym)
-      Rails.logger.debug "Connecting to #{current_connection_name}"
-      connect_to(current_connection_name) if different
+      if different
+        @@connection_name_stack.push(connection_name.to_sym)
+        Rails.logger.debug "Connecting to #{current_connection_name}"
+        connect_to(current_connection_name)
+      end
 
       yield connection_name
     ensure
-      @@connection_name_stack.pop
-      Rails.logger.debug "Restoring connection to #{current_connection_name}"
-      connect_to(current_connection_name) if different
+      if different
+        @@connection_name_stack.pop
+        Rails.logger.debug "Restoring connection to #{current_connection_name}"
+        connect_to(current_connection_name)
+      end
     end
 
     def transaction

--- a/lib/stagehand/engine.rb
+++ b/lib/stagehand/engine.rb
@@ -12,6 +12,7 @@ module Stagehand
       require "stagehand/cache"
       require "stagehand/key"
       require "stagehand/database"
+      require "stagehand/connection_adapter_extensions"
       require "stagehand/controller_extensions"
       require "stagehand/active_record_extensions"
       require "stagehand/staging"

--- a/lib/stagehand/version.rb
+++ b/lib/stagehand/version.rb
@@ -1,3 +1,3 @@
 module Stagehand
-  VERSION = "0.9.2"
+  VERSION = "0.10.0"
 end

--- a/lib/tasks/stagehand_tasks.rake
+++ b/lib/tasks/stagehand_tasks.rake
@@ -19,9 +19,11 @@ namespace :stagehand do
   def rake_both_databases(task, stagehand_task = task.gsub(':','_'))
     task(stagehand_task => :environment) do
       Stagehand::Database.each do |connection_name|
-        puts "#{connection_name}"
-        Rake::Task[task].reenable
-        Rake::Task[task].invoke
+        Stagehand::Connection.with_production_writes(ActiveRecord::Base) do
+          puts "#{connection_name}"
+          Rake::Task[task].reenable
+          Rake::Task[task].invoke
+        end
       end
       Rake::Task[task].clear
     end

--- a/spec/lib/helpers/database_spec.rb
+++ b/spec/lib/helpers/database_spec.rb
@@ -26,6 +26,12 @@ describe Stagehand::Database do
         end
       end
     end
+
+    it 'raises an exception if inserts are made while connected to production' do
+      subject.with_production_connection do
+        expect { SourceRecord.create! }.to raise_exception(Stagehand::ProductionWrite)
+      end
+    end
   end
 
   describe '::staging_connection' do
@@ -47,6 +53,7 @@ describe Stagehand::Database do
 
   describe '::production_connection' do
     without_transactional_fixtures
+    allow_unsynced_production_writes
 
     before { SourceRecord.establish_connection(Stagehand.configuration.production_connection_name) }
     after { SourceRecord.remove_connection }

--- a/spec/lib/helpers/database_spec.rb
+++ b/spec/lib/helpers/database_spec.rb
@@ -29,7 +29,7 @@ describe Stagehand::Database do
 
     it 'raises an exception if inserts are made while connected to production' do
       subject.with_production_connection do
-        expect { SourceRecord.create! }.to raise_exception(Stagehand::ProductionWrite)
+        expect { SourceRecord.create! }.to raise_exception(Stagehand::UnsyncedProductionWrite)
       end
     end
   end

--- a/spec/lib/staging/controller_spec.rb
+++ b/spec/lib/staging/controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'Stagehand::Staging::Controller', :type => :controller do
   without_transactional_fixtures
+  allow_unsynced_production_writes
 
   let(:staging) { Stagehand.configuration.staging_connection_name }
   let(:production) { Stagehand.configuration.production_connection_name }

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,3 +1,7 @@
+def allow_unsynced_production_writes
+  use_configuration :allow_unsynced_production_writes => true
+end
+
 def in_ghost_mode(&block)
   context 'in ghost mode' do
     use_configuration(:ghost_mode => true)


### PR DESCRIPTION
The connection is extended with callbacks that sets a readonly flag if connected to production. When writes are made to that database, an exception is raised. A known limitation is that writes made using the connection.execute method are not protected.