### PR TITLE
Pass subject to checklist if one was passed to sync_now.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 PATH
   remote: .
   specs:
-    culturecode_stagehand (0.10.2)
+    culturecode_stagehand (0.11.0)
       mysql2
       rails (~> 4.2)
+      ruby-graphviz
 
 GEM
   remote: https://rubygems.org/
@@ -119,6 +120,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    ruby-graphviz (1.2.2)
     slop (3.6.0)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)

--- a/lib/stagehand/staging/synchronizer.rb
+++ b/lib/stagehand/staging/synchronizer.rb
@@ -13,7 +13,8 @@ module Stagehand
         raise SyncBlockRequired unless block_given?
 
         Database.transaction do
-          checklist = Checklist.new(Commit.capture(subject_record, &block).entries)
+          commit = Commit.capture(subject_record, &block)
+          checklist = Checklist.new(subject_record || commit.entries)
           sync_checklist(checklist) unless checklist.requires_confirmation?
         end
       end

--- a/spec/lib/staging/synchronizer_spec.rb
+++ b/spec/lib/staging/synchronizer_spec.rb
@@ -195,6 +195,11 @@ describe Stagehand::Staging::Synchronizer do
       expect { subject.sync_now { source_record.increment!(:counter) } }.not_to change { Stagehand::Production.status(source_record) }
     end
 
+    it 'does sync records modified from within the block if they are the subject of an existing commit but that record is passed as the subject' do
+      Stagehand::Staging::Commit.capture(source_record) { source_record.increment!(:counter) }
+      expect { subject.sync_now(source_record) { source_record.increment!(:counter) } }.to change { Stagehand::Production.status(source_record) }
+    end
+
     it 'does not sync changes to records not modified in the block' do
       other_record = SourceRecord.create
       expect { subject.sync_now { source_record.increment!(:counter) } }.not_to change { Stagehand::Production.status(other_record) }


### PR DESCRIPTION
In sparkle, we pass the subject to `sync_now` in `update_credentialing`. We should take this as a sign that we want to confirm the subject and not just the entries created (or not pass the subject if we don't want that behaviour).