### PR TITLE
Pass in table_names as an argument

### DIFF
--- a/lib/stagehand/auditor.rb
+++ b/lib/stagehand/auditor.rb
@@ -20,11 +20,11 @@ module Stagehand
       return incomplete.to_h
     end
 
-    def mismatched_records
+    def mismatched_records(tables: Database.staging_connection.tables)
       output = {}
 
-      tables = Database.staging_connection.tables.select {|table_name| Schema::has_stagehand?(table_name) }
-      tables.each do |table_name|
+      stagehand_tables = Array(tables).select {|table_name| Schema::has_stagehand?(table_name) }
+      stagehand_tables.each do |table_name|
         print "\nChecking #{table_name} "
         mismatched = {}
         limit = 1000

--- a/lib/stagehand/auditor.rb
+++ b/lib/stagehand/auditor.rb
@@ -20,11 +20,11 @@ module Stagehand
       return incomplete.to_h
     end
 
-    def mismatched_records(tables: Database.staging_connection.tables)
+    def mismatched_records(options = {})
       output = {}
 
-      stagehand_tables = Array(tables).select {|table_name| Schema::has_stagehand?(table_name) }
-      stagehand_tables.each do |table_name|
+      tables = options[:tables] || Database.staging_connection.tables.select {|table_name| Schema::has_stagehand?(table_name) }
+      Array(tables).each do |table_name|
         print "\nChecking #{table_name} "
         mismatched = {}
         limit = 1000


### PR DESCRIPTION
- Able to specify table names to find mismatched records between the staging and production databases.
- Defaults to all tables