### PR TITLE
Fixes a bug that could result in destroyed commit logs

### DIFF
--- a/lib/stagehand/staging/synchronizer.rb
+++ b/lib/stagehand/staging/synchronizer.rb
@@ -32,10 +32,12 @@ module Stagehand
         deleted_count = 0
 
         Rails.logger.info "Syncing"
+
+        in_progress = CommitEntry.in_progress.pluck(:id)
         iterate_autosyncable_entries do |entry|
           sync_entry(entry, :callbacks => :sync)
           synced_count += 1
-          deleted_count += CommitEntry.matching(entry).delete_all
+          deleted_count += CommitEntry.matching(entry).no_newer_than(entry).where.not(:id => in_progress).delete_all
           break if synced_count == limit
         end
 

--- a/lib/stagehand/staging/synchronizer.rb
+++ b/lib/stagehand/staging/synchronizer.rb
@@ -30,13 +30,14 @@ module Stagehand
       def sync(limit = nil)
         synced_count = 0
         deleted_count = 0
+        in_progress = nil
 
         Rails.logger.info "Syncing"
 
-        in_progress = CommitEntry.in_progress.pluck(:id)
         iterate_autosyncable_entries do |entry|
           sync_entry(entry, :callbacks => :sync)
           synced_count += 1
+          in_progress ||= CommitEntry.in_progress.pluck(:id)
           deleted_count += CommitEntry.matching(entry).no_newer_than(entry).where.not(:id => in_progress).delete_all
           break if synced_count == limit
         end

--- a/lib/stagehand/version.rb
+++ b/lib/stagehand/version.rb
@@ -1,3 +1,3 @@
 module Stagehand
-  VERSION = "0.14.0"
+  VERSION = "0.14.1"
 end


### PR DESCRIPTION
We need to be certain we’re not deleting matching entries that belong to active commits. We can achieve this if we make a list of the entries in active commits before we start syncing, and only delete matching records that are not in that list, and that did not get created after the current entry being synced. Although simpler, for performance reasons we do not use the `not_in_progress` scope to limit the matching records as it makes the process more than 12x slower.