### PR TITLE
Allow production writes during Schema.define

### DIFF
--- a/lib/stagehand/engine.rb
+++ b/lib/stagehand/engine.rb
@@ -16,6 +16,7 @@ module Stagehand
       require "stagehand/connection_adapter_extensions"
       require "stagehand/controller_extensions"
       require "stagehand/active_record_extensions"
+      require "stagehand/schema_extensions"
       require "stagehand/staging"
       require "stagehand/production"
       require "stagehand/schema"

--- a/lib/stagehand/schema_extensions.rb
+++ b/lib/stagehand/schema_extensions.rb
@@ -1,0 +1,10 @@
+module Stagehand
+  module SchemaExtensions
+    def define(*)
+      # Allow production writes during Schema.define to allow Rails to write to ar_internal_metadata table
+      Stagehand::Connection.with_production_writes(ActiveRecord::Base) { super }
+    end
+  end
+end
+
+ActiveRecord::Schema.prepend(Stagehand::SchemaExtensions)


### PR DESCRIPTION
Rails writes to the ar_internal_metadata table during Schema.define.