### PR TITLE
More connection fixes

### DIFF
--- a/lib/stagehand/active_record_extensions.rb
+++ b/lib/stagehand/active_record_extensions.rb
@@ -34,6 +34,7 @@ ActiveRecord::Base.class_eval do
   # The original implementation of remove_connection uses @connection_specification_name, which is shared across Threads.
   # We need to pass in the connection that model in the current thread is using if we call remove_connection.
   def self.remove_connection(name = StagehandConnectionMap.get(self))
+    StagehandConnectionMap.set(self, nil)
     super
   end
 

--- a/lib/stagehand/active_record_extensions.rb
+++ b/lib/stagehand/active_record_extensions.rb
@@ -38,10 +38,11 @@ ActiveRecord::Base.class_eval do
   end
 
   def self.connection_specification_name=(connection_name)
+    StagehandConnectionMap.set(self, connection_name)
+
     # We want to keep track of the @connection_specification_name as a fallback shared across threads in case we
     # haven't set the connection on more than one thread.
     super
-    StagehandConnectionMap.set(self, connection_name)
   end
 
   def self.connection_specification_name

--- a/lib/stagehand/active_record_extensions.rb
+++ b/lib/stagehand/active_record_extensions.rb
@@ -39,6 +39,10 @@ ActiveRecord::Base.class_eval do
   end
 
   def self.connection_specification_name=(connection_name)
+    # ActiveRecord sets the connection pool to 'primary' by default, so we want to reuse that connection for staging
+    # in order to avoid using a different connection pool after our first swap back to the staging connection.
+    connection_name == 'primary' if connection_name == Stagehand::Configuration.staging_connection_name
+
     StagehandConnectionMap.set(self, connection_name)
 
     # We want to keep track of the @connection_specification_name as a fallback shared across threads in case we

--- a/lib/stagehand/connection_adapter_extensions.rb
+++ b/lib/stagehand/connection_adapter_extensions.rb
@@ -44,7 +44,7 @@ module Stagehand
       private
 
       def update_readonly_state
-        readonly! unless Configuration.single_connection? || @config[:database] != Database.production_database_name
+        readonly! unless Configuration.single_connection? || @config[:database] == Database.staging_database_name
       end
 
       def clear_readonly_state

--- a/lib/stagehand/database.rb
+++ b/lib/stagehand/database.rb
@@ -55,7 +55,7 @@ module Stagehand
       if different
         ConnectionStack.push(connection_name.to_sym)
         Rails.logger.debug "Connecting to #{current_connection_name}"
-        set_connection(ActiveRecord::Base, current_connection_name)
+        ActiveRecord::Base.connection_specification_name = current_connection_name
       else
         Rails.logger.debug "Already connected to #{connection_name}"
       end
@@ -65,7 +65,7 @@ module Stagehand
       if different
         ConnectionStack.pop
         Rails.logger.debug "Restoring connection to #{current_connection_name}"
-        set_connection(ActiveRecord::Base, current_connection_name)
+        ActiveRecord::Base.connection_specification_name = current_connection_name
       end
     end
 
@@ -82,18 +82,10 @@ module Stagehand
       return output
     end
 
-    def set_connection(klass, connection_name)
-      klass.connection_specification_name = connection_pool_name(connection_name)
-    end
-
     private
 
     def current_connection_name
       ConnectionStack.last
-    end
-
-    def connection_pool_name(connection_name)
-      connection_name == Configuration.staging_connection_name ? 'primary' : connection_name.to_s if connection_name
     end
 
     def database_name(connection_name)
@@ -111,8 +103,7 @@ module Stagehand
 
       # We fake the class name so we can create a connection pool with the desired connection name instead of the name of the class
       def self.init_connection(connection_name)
-        Stagehand::Database.set_connection(self, connection_name)
-        @probe_name = connection_specification_name
+        @probe_name = connection_name
         establish_connection(connection_name)
       ensure
         @probe_name = nil

--- a/lib/stagehand/database.rb
+++ b/lib/stagehand/database.rb
@@ -55,7 +55,7 @@ module Stagehand
       if different
         ConnectionStack.push(connection_name.to_sym)
         Rails.logger.debug "Connecting to #{current_connection_name}"
-        connect_to(current_connection_name)
+        set_connection(current_connection_name)
       else
         Rails.logger.debug "Already connected to #{connection_name}"
       end
@@ -65,7 +65,7 @@ module Stagehand
       if different
         ConnectionStack.pop
         Rails.logger.debug "Restoring connection to #{current_connection_name}"
-        connect_to(current_connection_name)
+        set_connection(current_connection_name)
       end
     end
 
@@ -82,11 +82,12 @@ module Stagehand
       return output
     end
 
-    private
-
-    def connect_to(connection_name)
-      ActiveRecord::Base.connection_specification_name = connection_name
+    def set_connection(connection_name, klass = ActiveRecord::Base)
+      connection_name = 'primary' if connection_name == Configuration.staging_connection_name
+      klass.connection_specification_name = connection_name
     end
+
+    private
 
     def current_connection_name
       ConnectionStack.last
@@ -104,11 +105,11 @@ module Stagehand
 
     class Probe < ActiveRecord::Base
       self.abstract_class = true
-      class_attribute :connection_name
 
       # We fake the class name so we can create a connection pool with the desired connection name instead of the name of the class
-      def self.init_connection
-        @probe_name = connection_name
+      def self.init_connection(connection_name)
+        Stagehand::Database.set_connection(connection_name, self)
+        @probe_name = connection_specification_name
         establish_connection(connection_name)
       ensure
         @probe_name = nil
@@ -121,14 +122,22 @@ module Stagehand
 
     class StagingProbe < Probe
       self.abstract_class = true
-      self.connection_name = Configuration.staging_connection_name
+
+      def self.init_connection
+        super(Configuration.staging_connection_name)
+      end
+
       init_connection
     end
 
     class ProductionProbe < Probe
       self.abstract_class = true
-      self.connection_name = Configuration.production_connection_name
-      init_connection
+
+      def self.init_connection
+        super(Configuration.production_connection_name)
+      end
+
+      init_connection unless Configuration.single_connection?
     end
 
     # Threadsafe tracking of the connection stack

--- a/lib/stagehand/version.rb
+++ b/lib/stagehand/version.rb
@@ -1,3 +1,3 @@
 module Stagehand
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/lib/active_record_extensions_spec.rb
+++ b/spec/lib/active_record_extensions_spec.rb
@@ -77,5 +77,14 @@ describe 'ActiveRecordExtensions' do
       thread1.join
       thread2.join
     end
+
+    it 'unsets connection_specification_name for the given class' do
+      config = ActiveRecord::Base.configurations[Stagehand::Configuration.staging_connection_name]
+      ConnectionTestMock.establish_connection(config)
+
+      expect { ConnectionTestMock.remove_connection }
+        .to change { ConnectionTestMock.connection_specification_name }
+        .to(ConnectionTestMock.superclass.connection_specification_name)
+    end
   end
 end

--- a/spec/lib/helpers/database_spec.rb
+++ b/spec/lib/helpers/database_spec.rb
@@ -46,9 +46,7 @@ describe Stagehand::Database do
 
   describe '::staging_connection' do
     without_transactional_fixtures
-
-    before { SourceRecord.establish_connection(Stagehand.configuration.staging_connection_name) }
-    after { SourceRecord.remove_connection }
+    use_then_clear_connection_for_class(SourceRecord, Stagehand.configuration.staging_connection_name)
 
     it 'returns a connection object that uses the staging database' do
       expect { SourceRecord.create }.to change { subject.staging_connection.select_values(SourceRecord.all) }
@@ -64,9 +62,7 @@ describe Stagehand::Database do
   describe '::production_connection' do
     without_transactional_fixtures
     allow_unsynced_production_writes
-
-    before { SourceRecord.establish_connection(Stagehand.configuration.production_connection_name) }
-    after { SourceRecord.remove_connection }
+    use_then_clear_connection_for_class(SourceRecord, Stagehand.configuration.production_connection_name)
 
     it 'returns a connection object that uses the staging database' do
       expect { SourceRecord.create }.to change { subject.production_connection.select_values(SourceRecord.all) }

--- a/spec/lib/production_spec.rb
+++ b/spec/lib/production_spec.rb
@@ -2,6 +2,12 @@ describe Stagehand::Production do
   subject { Stagehand::Production }
   let(:source_record) { SourceRecord.create }
 
+  in_single_connection_mode do
+    it 'uses the same connection object as ActiveRecord::Base' do
+      expect(Stagehand::Production::Record.connection).to be(ActiveRecord::Base.connection)
+    end
+  end
+
   describe '::status' do
     it 'returns :new if the record does not exist in the production database' do
       expect(subject.status(source_record)).to eq(:new)

--- a/spec/lib/staging/controller_spec.rb
+++ b/spec/lib/staging/controller_spec.rb
@@ -71,8 +71,8 @@ describe 'Stagehand::Staging::Controller', :type => :controller do
     end
 
     it 'once again affects the connection of models that have had their connection removed' do
-      Stagehand::Database.set_connection(SourceRecord, production)
-      Stagehand::Database.set_connection(SourceRecord, nil)
+      SourceRecord.connection_specification_name = production
+      SourceRecord.connection_specification_name = nil
       expect { get :index }.to change { StagingSourceRecord.count }.by(1)
     end
 

--- a/spec/lib/staging/controller_spec.rb
+++ b/spec/lib/staging/controller_spec.rb
@@ -64,15 +64,15 @@ describe 'Stagehand::Staging::Controller', :type => :controller do
       expect(SourceRecord.last).to eq(record)
     end
 
-    it 'does not affect the connection of models that have specifically called establish_connection' do
-      SourceRecord.establish_connection(production)
-      expect { get :index }.not_to change { StagingSourceRecord.count }
-      SourceRecord.remove_connection
+    it 'does not affect the connection of models that have specifically defined a connection' do
+      set_then_clear_connection_for_class(SourceRecord, production) do
+        expect { get :index }.not_to change { StagingSourceRecord.count }
+      end
     end
 
     it 'once again affects the connection of models that have had their connection removed' do
-      SourceRecord.establish_connection(production)
-      SourceRecord.remove_connection
+      Stagehand::Database.set_connection(SourceRecord, production)
+      Stagehand::Database.set_connection(SourceRecord, nil)
       expect { get :index }.to change { StagingSourceRecord.count }.by(1)
     end
 

--- a/spec/lib/staging/model_spec.rb
+++ b/spec/lib/staging/model_spec.rb
@@ -8,7 +8,7 @@ describe Stagehand::Staging::Model do
     let(:staging) { Rails.configuration.database_configuration[Stagehand.configuration.staging_connection_name.to_s] }
 
     it 'establishes a connection to the staging database' do
-      klass.establish_connection(Stagehand.configuration.production_connection_name)
+      Stagehand::Database.set_connection(klass, Stagehand.configuration.production_connection_name)
       expect { klass.include(subject) }.to change { klass.connection.current_database }.to(staging['database'])
     end
 
@@ -23,7 +23,7 @@ describe Stagehand::Staging::Model do
 
     in_ghost_mode do
       it 'does not change the connection' do
-        klass.establish_connection(Stagehand.configuration.production_connection_name)
+        Stagehand::Database.set_connection(klass, Stagehand.configuration.production_connection_name)
         expect { klass.include(subject) }.not_to change { klass.connection.current_database }
       end
     end

--- a/spec/lib/staging/model_spec.rb
+++ b/spec/lib/staging/model_spec.rb
@@ -8,7 +8,7 @@ describe Stagehand::Staging::Model do
     let(:staging) { Rails.configuration.database_configuration[Stagehand.configuration.staging_connection_name.to_s] }
 
     it 'establishes a connection to the staging database' do
-      Stagehand::Database.set_connection(klass, Stagehand.configuration.production_connection_name)
+      klass.connection_specification_name = Stagehand.configuration.production_connection_name
       expect { klass.include(subject) }.to change { klass.connection.current_database }.to(staging['database'])
     end
 
@@ -23,7 +23,7 @@ describe Stagehand::Staging::Model do
 
     in_ghost_mode do
       it 'does not change the connection' do
-        Stagehand::Database.set_connection(klass, Stagehand.configuration.production_connection_name)
+        klass.connection_specification_name = Stagehand.configuration.production_connection_name
         expect { klass.include(subject) }.not_to change { klass.connection.current_database }
       end
     end

--- a/spec/lib/staging/synchronizer_spec.rb
+++ b/spec/lib/staging/synchronizer_spec.rb
@@ -411,10 +411,7 @@ describe Stagehand::Staging::Synchronizer do
     it_behaves_like 'sync callbacks'
   end
 
-  context 'in a single database configuration' do
-    connection = Stagehand.configuration.staging_connection_name
-    use_configuration(:staging_connection_name => connection, :production_connection_name => connection)
-
+  in_single_connection_mode do
     it_behaves_like 'sync callbacks'
   end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -60,8 +60,8 @@ def use_then_clear_connection_for_class(klass, connection_name)
 end
 
 def set_then_clear_connection_for_class(klass, connection_name, &block)
-  Stagehand::Database.set_connection(klass, connection_name)
+  klass.connection_specification_name = connection_name
   block.call
 ensure
-  Stagehand::Database.set_connection(klass, nil)
+  klass.connection_specification_name = nil
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -50,3 +50,18 @@ def without_transactional_fixtures
   #
   # This is now just a no-op to indicate which tests would require this since we no longer use transactional fixtures
 end
+
+def use_then_clear_connection_for_class(klass, connection_name)
+  around do |example|
+    set_then_clear_connection_for_class(klass, connection_name) do
+      example.run
+    end
+  end
+end
+
+def set_then_clear_connection_for_class(klass, connection_name, &block)
+  Stagehand::Database.set_connection(klass, connection_name)
+  block.call
+ensure
+  Stagehand::Database.set_connection(klass, nil)
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -9,6 +9,14 @@ def in_ghost_mode(&block)
   end
 end
 
+def in_single_connection_mode(&block)
+  context 'in a single database configuration' do
+    connection = Stagehand.configuration.staging_connection_name
+    use_configuration(:staging_connection_name => connection, :production_connection_name => connection)
+    instance_exec(&block)
+  end
+end
+
 def use_configuration(new_configuration)
   around do |example|
     with_configuration(new_configuration) do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -39,19 +39,17 @@ RSpec.configure do |config|
       end
     end
 
-    ActiveRecord::Base.establish_connection(Stagehand.configuration.staging_connection_name)
+    Stagehand::Database.with_connection(Stagehand.configuration.staging_connection_name) do
+      # Add stagehand to the staging database
+      Stagehand::Schema.init_stagehand!
 
-    # Add stagehand to the staging database
-    Stagehand::Schema.init_stagehand!
-
-    # Add a table to the staging side that doesn't appear on the production side and doesn't have stagehand
-    ActiveRecord::Schema.define do
-      create_table :users, :force => true, :stagehand => false do |t|
-        t.timestamps :null => false
+      # Add a table to the staging side that doesn't appear on the production side and doesn't have stagehand
+      ActiveRecord::Schema.define do
+        create_table :users, :force => true, :stagehand => false do |t|
+          t.timestamps :null => false
+        end
       end
     end
-
-    ActiveRecord::Base.establish_connection(:test)
   end
 end
 


### PR DESCRIPTION
Tweaks to simplify usage in the host app under a number of situations. Specifically we want to reuse the default connection unless we connect to the production database in order avoid unexpected behaviour during host app tests that involve transactions.