### PR TITLE
Don’t preload non-preloadable associations.

### DIFF
--- a/lib/stagehand/staging/checklist.rb
+++ b/lib/stagehand/staging/checklist.rb
@@ -89,7 +89,18 @@ module Stagehand
       private
 
       def self.associated_associations(klass)
-        cache("#{klass.name}_associated_associations") { klass.reflect_on_all_associations(:belongs_to).collect(&:name) }
+        cache("#{klass.name}_associated_associations") do
+          reflections = klass.reflect_on_all_associations(:belongs_to)
+
+          reflections.select! do |reflection|
+            reflection.check_preloadable!
+            next true
+          rescue ArgumentError
+            next false
+          end
+
+          reflections.collect(&:name)
+        end
       end
 
       def self.stagehand_class?(klass)

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -28,12 +28,14 @@ ActiveRecord::Schema.define(version: 0) do
     t.string "name"
     t.integer "counter"
     t.string "type"
+    t.bigint "target_assignment_id"
     t.bigint "user_id"
     t.string "attachable_type"
     t.bigint "attachable_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["attachable_type", "attachable_id"], name: "index_source_records_on_attachable_type_and_attachable_id"
+    t.index ["target_assignment_id"], name: "index_source_records_on_target_assignment_id"
     t.index ["user_id"], name: "index_source_records_on_user_id"
   end
 

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -17,6 +17,7 @@ RSpec.configure do |config|
             t.string :name
             t.integer :counter
             t.string :type
+            t.references :target_assignment
             t.references :user
             t.references :attachable, :polymorphic => true
             t.timestamps :null => true
@@ -61,6 +62,10 @@ end
 class SourceRecord < ActiveRecord::Base
   belongs_to :user
   belongs_to :attachable, :polymorphic => true
+
+  # Scoped instance-dependent association to test fix for https://github.com/culturecode/stagehand/issues/52
+  belongs_to :target_assignment, ->(record) { where source_record: record }
+
   has_many :target_assignments
   has_many :targets, through: :target_assignments
 end


### PR DESCRIPTION
We can’t preload associations that have an instance dependant scope. We now filter these out by checking each association to see if they are preloadable.

Closes https://github.com/culturecode/stagehand/issues/52.