### PR TITLE
Allow cross database joins for staging models.

### DIFF
--- a/lib/stagehand/configuration.rb
+++ b/lib/stagehand/configuration.rb
@@ -9,7 +9,8 @@ module Stagehand
   module Configuration
     extend self
 
-    mattr_accessor :checklist_confirmation_filter, :checklist_association_filter, :checklist_relation_filter, :ignored_columns
+    mattr_accessor :checklist_confirmation_filter, :checklist_association_filter, :checklist_relation_filter, :staging_model_tables, :ignored_columns
+    self.staging_model_tables = Set.new
     self.ignored_columns = HashWithIndifferentAccess.new
 
     def staging_connection_name

--- a/lib/stagehand/connection_adapter_extensions.rb
+++ b/lib/stagehand/connection_adapter_extensions.rb
@@ -17,6 +17,13 @@ module Stagehand
     end
 
     module AdapterExtensions
+      def quote_table_name(table_name)
+        return super unless Database.connected_to_production?
+        return super unless Configuration.staging_model_tables.include?(table_name)
+
+        super "#{Stagehand::Database.staging_database_name}.#{table_name}"
+      end
+
       def exec_insert(*)
         handle_readonly_writes!
         super

--- a/lib/stagehand/staging/model.rb
+++ b/lib/stagehand/staging/model.rb
@@ -3,6 +3,10 @@ module Stagehand
     module Model
       extend ActiveSupport::Concern
 
+      included do
+        Stagehand::Configuration.staging_model_tables << table_name
+      end
+
       class_methods do
         def connection
           if Configuration.ghost_mode?

--- a/spec/lib/staging/model_spec.rb
+++ b/spec/lib/staging/model_spec.rb
@@ -12,6 +12,22 @@ describe Stagehand::Staging::Model do
       expect { klass.include(subject) }.to change { klass.connection.current_database }.to(staging['database'])
     end
 
+    it 'prefixes the table name with the database name when the current connection is production' do
+      klass.include(subject)
+
+      Stagehand::Database.with_production_connection do
+        expect(klass.all.to_sql).to include("FROM `#{klass.connection.current_database}`.`#{klass.table_name}`")
+      end
+    end
+
+    it 'does not prefix the table name with the database name when the current connection is staging' do
+      klass.include(subject)
+
+      Stagehand::Database.with_staging_connection do
+        expect(klass.all.to_sql).not_to include("FROM `#{klass.connection.current_database}`.`#{klass.table_name}`")
+      end
+    end
+
     it 'does not get written if part of a failed transaction' do
       klass.include(subject)
       Stagehand::Database.with_staging_connection do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,5 +23,7 @@ RSpec.configure do |config|
   config.append_after(:each) do
     DatabaseCleaner.strategy = :deletion
     DatabaseCleaner.clean
+
+    Stagehand::Configuration.staging_model_tables = Set.new
   end
 end


### PR DESCRIPTION
We now keep track of all staging model table names and append the DB name when referencing them on the live side. This allows us to do cross-database joins in MySQL. This is useful because it allows us to stop copying tables just to be able to perform joins on the live site.