### PR TITLE
Use arel to read and write

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    culturecode_stagehand (1.1.5)
+    culturecode_stagehand (1.1.7)
       mysql2
       rails (>= 4.2)
       ruby-graphviz
@@ -75,12 +75,12 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.4)
+    mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     mysql2 (0.4.10)
-    nio4r (2.5.2)
+    nio4r (2.5.3)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pry (0.12.2)
@@ -137,7 +137,7 @@ GEM
     rspec-support (3.8.0)
     ruby-graphviz (1.2.5)
       rexml
-    sprockets (4.0.0)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -148,9 +148,9 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    websocket-driver (0.7.1)
+    websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
 
 PLATFORMS
   ruby

--- a/lib/stagehand/version.rb
+++ b/lib/stagehand/version.rb
@@ -1,3 +1,3 @@
 module Stagehand
-  VERSION = "1.1.6"
+  VERSION = "1.1.7"
 end


### PR DESCRIPTION
We had an issue where by changing to using an instance of a model to read from the staging database instead of a pure `connection.select_one` SQL statement, we would unintentionally read from the wrong table because Rails would cache prepared `find_by` statements. This was fixed in f4ddbcc by resetting column information after we pointed the reader at a different table, however, this solution seemed to further complicate the reading process and suggested that our original idea to move away from low-level reads in order to fix JSON column typcasting was flawed.

Instead, we double down on low-level database manipulation. We revert to low-level, un-typecast reads, and ensure that we also write using low-level methods that expect un-typecast data. This ensures that even though a JSON object comes out of the database as a string of JSON, when we write it back we don’t unintentionally typecast it to a JSON string of JSON, and instead treat it as though it is a raw value going back into the database as we did when it came out.