### PR TITLE
Allow rake db:create in the wrapping app

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,13 @@ rescue LoadError
   puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
 end
 
-APP_RAKEFILE = File.expand_path("../spec/internal/Rakefile", __FILE__)
-load 'rails/tasks/engine.rake'
+# While I am not sure, if rails' engine rake tasks are usuable with this app
+# I leave the config in, but commented out
+#
+# APP_PATH = File.expand_path("spec/internal", __dir__)
+# ENGINE_ROOT = File.expand_path("spec/internal", __dir__)
+# APP_RAKEFILE = File.expand_path("spec/internal/Rakefile", __dir__)
+# load 'rails/tasks/engine.rake'
 
 load 'rails/tasks/statistics.rake'
 

--- a/lib/stagehand/connection_adapter_extensions.rb
+++ b/lib/stagehand/connection_adapter_extensions.rb
@@ -65,4 +65,8 @@ module Stagehand
   class UnsyncedProductionWrite < StandardError; end
 end
 
-ActiveRecord::Base.connection.class.prepend(Stagehand::Connection::AdapterExtensions)
+begin
+  ActiveRecord::Base.connection.class.prepend(Stagehand::Connection::AdapterExtensions)
+rescue ActiveRecord::NoDatabaseError => e
+  Rails.logger.debug("#{e.class.name}, #{e.to_s} - continuing anyway, as we expect DB creation")
+end

--- a/lib/stagehand/schema/statements.rb
+++ b/lib/stagehand/schema/statements.rb
@@ -51,5 +51,10 @@ module Stagehand
   end
 end
 
-ActiveRecord::Base.connection.class.include Stagehand::Schema::Statements
+begin
+  ActiveRecord::Base.connection.class.include Stagehand::Schema::Statements
+rescue ActiveRecord::NoDatabaseError => e
+  Rails.logger.debug("#{e.class.name}, #{e.to_s} - continuing anyway, as we expect DB creation")
+end
+
 ActiveRecord::SchemaDumper.prepend Stagehand::Schema::DumperExtensions

--- a/lib/stagehand/staging/synchronizer.rb
+++ b/lib/stagehand/staging/synchronizer.rb
@@ -7,7 +7,11 @@ module Stagehand
       BATCH_SIZE = 1000
       SESSION_BATCH_SIZE = 30
       ENTRY_SYNC_ORDER = [:delete, :update, :insert].freeze
-      ENTRY_SYNC_ORDER_SQL = ActiveRecord::Base.send(:sanitize_sql_for_order, ['FIELD(operation, ?), id DESC', ENTRY_SYNC_ORDER]).freeze
+      ENTRY_SYNC_ORDER_SQL =  begin
+                                ActiveRecord::Base.send(:sanitize_sql_for_order, ['FIELD(operation, ?), id DESC', ENTRY_SYNC_ORDER]).freeze
+                              rescue ActiveRecord::NoDatabaseError => e
+                                Rails.logger.debug("#{e.class.name}, #{e.to_s} - continuing anyway, as we expect DB creation")
+                              end
 
       # Immediately attempt to sync the changes from the block if possible
       # The block is wrapped in a transaction to prevent changes to records while being synced

--- a/spec/internal/Rakefile
+++ b/spec/internal/Rakefile
@@ -1,0 +1,9 @@
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+# ENGINE_ROOT = File.expand_path("./", __dir__)
+# APP_RAKEFILE = File.expand_path("./Rakefile", __dir__)
+# load 'rails/tasks/engine.rake'


### PR DESCRIPTION
These changes enable to run `rake db:create` in Sparkle - which would be most welcome on the CI, but also needed to use the parallel_tests gem.

Now, I know just rescuing an error can be seen as hacky. In this case I think we only run into this error on `db:create` anyway - and if we would run into the issue that the database is missing then something else would break. But I am looking forward to your opinions.