### PR TITLE
Ensure that transactions cannot be retried.

### DIFF
--- a/spec/lib/helpers/database_spec.rb
+++ b/spec/lib/helpers/database_spec.rb
@@ -99,5 +99,12 @@ describe Stagehand::Database do
       expect { subject.transaction { Stagehand::Production.save(record); raise ActiveRecord::Rollback } rescue nil }
         .not_to change { Stagehand::Production.status(record) }
     end
+
+    it 'does not allow the transaction to be retried' do
+      record = SourceRecord.create
+
+      expect { ActiveRecord::Base.with_transaction_retry_enabled { subject.transaction { Stagehand::Production.save(record); raise ActiveRecord::Rollback } } }
+        .to raise_exception(Stagehand::Database::NoRetryError)
+    end
   end
 end


### PR DESCRIPTION
We want to ensure that the inner transaction in Database.transaction cannot be retried. If we allow retries, this would allow the second attempt to write to the staging database succeed and any changes made to the live database on the first attempt would not be rolled back.

Closes https://github.com/Atrium-Health/sparkle-atrium/issues/850.