### PR TITLE
Expunge Commit Entries on remove_stagehand!

### DIFF
--- a/lib/stagehand/schema/statements.rb
+++ b/lib/stagehand/schema/statements.rb
@@ -17,7 +17,7 @@ module Stagehand
       def rename_table(old_table_name, new_table_name, *)
         return super unless Schema.has_stagehand?(old_table_name)
 
-        Schema.remove_stagehand!(:only => old_table_name)
+        Schema.remove_stagehand!(:only => old_table_name, :remove_entries => false)
         super
         Schema.add_stagehand!(:only => new_table_name)
         Staging::CommitEntry.where(:table_name => old_table_name).update_all(:table_name => new_table_name)
@@ -26,9 +26,8 @@ module Stagehand
       def drop_table(table_name, *)
         return super unless Schema.has_stagehand?(table_name) && table_exists?(Staging::CommitEntry.table_name)
 
+        Schema.remove_stagehand!(:only => table_name, :remove_entries => true)
         super
-        Staging::CommitEntry.where(:table_name => table_name).delete_all
-        Staging::Commit.empty.each(&:destroy)
       end
     end
 

--- a/lib/stagehand/staging/commit.rb
+++ b/lib/stagehand/staging/commit.rb
@@ -131,12 +131,16 @@ module Stagehand
         id == other.id
       end
 
-      def entries
-        CommitEntry.where(:id => @start_id..@end_id).where(:commit_id => id)
+      def subject
+        start_entry.record
       end
 
-      def subject
-        entries.sort_by(&:id).first.record
+      def start_entry
+        CommitEntry.find(@start_id)
+      end
+
+      def end_entry
+        entries.end_operations.first
       end
 
       def empty?
@@ -145,6 +149,10 @@ module Stagehand
 
       def destroy
         entries.delete_all
+      end
+
+      def entries
+        CommitEntry.where(:id => @start_id..@end_id).where(:commit_id => id)
       end
     end
   end

--- a/lib/stagehand/staging/commit_entry.rb
+++ b/lib/stagehand/staging/commit_entry.rb
@@ -20,6 +20,8 @@ module Stagehand
       scope :control_operations,    lambda { where(:operation => CONTROL_OPERATIONS) }
       scope :content_operations,    lambda { where(:operation => CONTENT_OPERATIONS) }
       scope :save_operations,       lambda { where(:operation => SAVE_OPERATIONS) }
+      scope :insert_operations,     lambda { where(:operation => INSERT_OPERATION) }
+      scope :update_operations,     lambda { where(:operation => UPDATE_OPERATION) }
       scope :delete_operations,     lambda { where(:operation => DELETE_OPERATION) }
       scope :with_record,           lambda { where.not(:record_id => nil) }
       scope :uncontained,           lambda { where(:commit_id => nil) }


### PR DESCRIPTION
When removing stagehand from a table, we generally want to remove all associated commit entries. We do already enhance the `drop_table` method with this behaviour, however, if `remove_stagehand!` is called manually before dropping the table, we would not end up deleting the commit entries for that table.

Instead, we make the cleanup process part of `remove_stagehand!`.