### PR TITLE
fix(ci): sync gemfile lockfiles with 2.0.1 release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    combinaut_stagehand (2.0.0)
+    combinaut_stagehand (2.0.1)
       mysql2
       rails (>= 7.0, < 8.2)
       ruby-graphviz

--- a/gemfiles/rails_7.0.gemfile.lock
+++ b/gemfiles/rails_7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    combinaut_stagehand (2.0.0)
+    combinaut_stagehand (2.0.1)
       mysql2
       rails (>= 7.0, < 8.2)
       ruby-graphviz

--- a/gemfiles/rails_7.1.gemfile.lock
+++ b/gemfiles/rails_7.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    combinaut_stagehand (2.0.0)
+    combinaut_stagehand (2.0.1)
       mysql2
       rails (>= 7.0, < 8.2)
       ruby-graphviz

--- a/gemfiles/rails_7.2.gemfile.lock
+++ b/gemfiles/rails_7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    combinaut_stagehand (2.0.0)
+    combinaut_stagehand (2.0.1)
       mysql2
       rails (>= 7.0, < 8.2)
       ruby-graphviz

--- a/gemfiles/rails_8.0.gemfile.lock
+++ b/gemfiles/rails_8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    combinaut_stagehand (2.0.0)
+    combinaut_stagehand (2.0.1)
       mysql2
       rails (>= 7.0, < 8.2)
       ruby-graphviz

--- a/gemfiles/rails_8.1.gemfile.lock
+++ b/gemfiles/rails_8.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    combinaut_stagehand (2.0.0)
+    combinaut_stagehand (2.0.1)
       mysql2
       rails (>= 7.0, < 8.2)
       ruby-graphviz


### PR DESCRIPTION
The version bump in 7102c32 updated `lib/stagehand/version.rb` to `2.0.1` but left `Gemfile.lock` and the appraisal `gemfiles/*.gemfile.lock` files still pinned at `combinaut_stagehand (2.0.0)`. CI runs `bundle install` in frozen mode, which refuses to reconcile the mismatch and fails every matrix job at the Ruby setup step with:

```
The gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set
```

Running `bundle install` against each appraisal regenerates only this single-line change in each lockfile — no other dependency churn.

### Changes
  - Bump `combinaut_stagehand` from `2.0.0` → `2.0.1` in `Gemfile.lock` and all five `gemfiles/rails_*.gemfile.lock` files.

### UAT Steps
1. Confirm CI is green on this PR across the full Ruby × Rails matrix.